### PR TITLE
Slack Webhook環境変数名をプロジェクト固有の命名に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ color: blue|red|green|...
 
 3. **フック設定**
    - `hooks/hooks.json`でイベントハンドラーを定義
-   - 環境変数`SLACK_WEBHOOK_URL`が必要
+   - 環境変数`ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL`が必要
 
 ### テストとデバッグ
 
@@ -131,7 +131,7 @@ claude plugin install eccube-dev-agents
 
 ### 環境変数
 
-- `SLACK_WEBHOOK_URL`: Slack通知に必須
+- `ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL`: Slack通知に必須
 
 ### ファイル形式
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The repository uses a nested structure where the actual plugin contents are in `
 For Slack notifications to work, set your Slack webhook URL:
 
 ```bash
-export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
+export ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
 ```
 
 Add this to your `~/.bashrc` or `~/.zshrc` to make it persistent.

--- a/plugins/eccube-dev-agents/hooks/hooks.json
+++ b/plugins/eccube-dev-agents/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "transcript_path=$(jq -r '.transcript_path') && title=$(jq -r '.title') && jq -s '.[-3:]' \"$transcript_path\" | gemini -m gemini-2.5-flash -p \"タスク確認の通知です。タイトル: $title\\nこの会話の内容を日本語で簡潔に要約してください。絵文字を使って読みやすくしてください。Slack の mrkdwn 形式を使用してください。\" | jq -Rs '{\"blocks\": [{\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": .}}]}' | curl -X POST -H 'Content-type: application/json' -d @- ${SLACK_WEBHOOK_URL}"
+            "command": "transcript_path=$(jq -r '.transcript_path') && title=$(jq -r '.title') && jq -s '.[-3:]' \"$transcript_path\" | gemini -m gemini-2.5-flash -p \"タスク確認の通知です。タイトル: $title\\nこの会話の内容を日本語で簡潔に要約してください。絵文字を使って読みやすくしてください。Slack の mrkdwn 形式を使用してください。\" | jq -Rs '{\"blocks\": [{\"type\": \"section\", \"text\": {\"type\": \"mrkdwn\", \"text\": .}}]}' | curl -X POST -H 'Content-type: application/json' -d @- ${ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL}"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "transcript_path=$(jq -r '.transcript_path') && jq -s '.[-3:]' \\\"$transcript_path\\\" | gemini -m gemini-2.5-flash -p 'タスク完了の通知です。この会話の内容を日本語で簡潔に要約してください。絵文字を使って読みやすくしてください。Slack の mrkdwn 形式を使用してください。' | jq -Rs '{\\\"blocks\\\": [{\\\"type\\\": \\\"section\\\", \\\"text\\\": {\\\"type\\\": \\\"mrkdwn\\\", \\\"text\\\": .}}]}' | curl -X POST -H 'Content-type: application/json' -d @- ${SLACK_WEBHOOK_URL}"
+            "command": "transcript_path=$(jq -r '.transcript_path') && jq -s '.[-3:]' \\\"$transcript_path\\\" | gemini -m gemini-2.5-flash -p 'タスク完了の通知です。この会話の内容を日本語で簡潔に要約してください。絵文字を使って読みやすくしてください。Slack の mrkdwn 形式を使用してください。' | jq -Rs '{\\\"blocks\\\": [{\\\"type\\\": \\\"section\\\", \\\"text\\\": {\\\"type\\\": \\\"mrkdwn\\\", \\\"text\\\": .}}]}' | curl -X POST -H 'Content-type: application/json' -d @- ${ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL}"
           }
         ]
       }


### PR DESCRIPTION
## 概要

Slack Webhook URLの環境変数名を、他のプロジェクトとの重複を避けるためにプロジェクト固有の命名規則に変更しました。

## 変更内容

- 環境変数名を `SLACK_WEBHOOK_URL` から `ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL` に変更
- フック設定、ドキュメント、セットアップガイドを一貫して更新

## 変更理由

1. **名前の衝突回避**: 汎用的な `SLACK_WEBHOOK_URL` は他のプロジェクトやプラグインと重複しやすい
2. **明確な識別性**: プロジェクト固有のプレフィックスにより、環境変数の用途が明確になる
3. **保守性向上**: 複数のClaude Codeプラグインを使用する際の管理が容易になる

## 影響を受けるファイル

- `plugins/eccube-dev-agents/hooks/hooks.json` - NotificationフックとStopフックの環境変数参照
- `README.md` - 環境変数設定例
- `CLAUDE.md` - 環境変数ドキュメント

## 移行手順

既存ユーザーは、環境変数を再設定する必要があります:

\`\`\`bash
# 新しい環境変数名を設定
export ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"

# ~/.bashrc または ~/.zshrc に追加して永続化
echo 'export ECCUBE_DEV_AGENTS_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"' >> ~/.bashrc
\`\`\`

## テスト計画

- [ ] 新しい環境変数でSlack通知が正常に動作することを確認
- [ ] ドキュメントが正確であることを確認
- [ ] プラグインのインストールと設定手順を検証