### PR TITLE
fix(workflows): prompt を --system-prompt に変更してユーザーコメントを保持

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,14 +35,19 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
 
-            ユーザーがプルリクエストに `/claude review` とコメントしてコードレビューをリクエストしました。
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: |
+            --allowed-tools "Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --system-prompt "REPO: ${{ github.repository }}
+
+            ユーザーがプルリクエストに /claude review とコメントしてコードレビューをリクエストしました。
 
             **重要な指示:**
             - すべてのレビューコメント、説明、フィードバックは日本語で記述してください
             - コード内のコメントも日本語で記述してください
+            - レビュー完了後は必ずPRにコメントを投稿して、レビュー結果を報告してください
 
             以下の観点からプルリクエストをレビューしてフィードバックを提供してください：
             - コード品質とベストプラクティス
@@ -54,11 +59,7 @@ jobs:
             リポジトリのCLAUDE.mdを参照して、スタイルと規約に関するガイダンスを確認してください。建設的で役立つフィードバックを心がけてください。
 
             手順：
-            1. まず `gh pr view` を使用して現在のPRコンテキストを特定する
+            1. まず gh pr view を使用して現在のPRコンテキストを特定する
             2. PRの変更内容をレビューする
-            3. `gh pr comment` または `gh issue comment` を使用してレビュー結果をコメントとして投稿する
-
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+            3. gh pr comment または gh issue comment を使用してレビュー結果をコメントとして投稿する"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,18 +43,15 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Custom prompt to ensure Japanese responses
-          prompt: |
-            ユーザーからのリクエストを実行してください。
-
-            **重要な指示:**
+          # Allow Claude to post comments on PRs and issues, and configure Japanese responses
+          claude_args: |
+            --allowed-tools "Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh issue list:*)"
+            --system-prompt "**重要な指示:**
             - すべての回答、説明、コメントは日本語で記述してください
             - コード内のコメントも日本語で記述してください
             - コミットメッセージは日本語で記述してください
-            - PRやIssueへのコメント投稿には `gh pr comment` または `gh issue comment` コマンドを使用してください
+            - PRやIssueへのコメント投稿には gh pr comment または gh issue comment コマンドを使用してください
+            - 作業完了後は必ず元のIssueまたはPRにコメントを投稿して、実施した内容を報告してください
 
-            リポジトリのCLAUDE.mdファイルを参照して、プロジェクトのスタイルと規約に従ってください。
-
-          # Allow Claude to post comments on PRs and issues
-          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh issue list:*)"'
+            リポジトリのCLAUDE.mdファイルを参照して、プロジェクトのスタイルと規約に従ってください。"
 


### PR DESCRIPTION
## Summary

GitHub Actions ワークフローで `prompt` パラメータを `--system-prompt` に変更し、ユーザーのコメント内容が正しく Claude Code に渡されるように修正しました。

## Changes

- **`.github/workflows/claude.yml`**: `prompt:` フィールドを削除し、`claude_args` に `--system-prompt` を追加
- **`.github/workflows/claude-code-review.yml`**: 同様の修正を適用

### 主な変更内容

1. **`prompt` の削除**: ユーザーのコメント内容を上書きしてしまう問題を解決
2. **`--system-prompt` の採用**: システム指示として追加され、ユーザーの指示を保持
3. **作業完了後のコメント投稿指示を追加**: Claude Code が作業完了後に必ずコメントを投稿するように明示

### 修正による効果

- ✅ `@claude` コマンドでユーザーの実際の指示内容が Claude Code に渡される
- ✅ `/claude review` コマンドで追加の指示（例: セキュリティ面を重点的に）が有効になる
- ✅ 日本語応答などのカスタム指示も継続して適用される
- ✅ 作業完了後に自動的にコメントが投稿される

## Test plan

- [ ] 修正後のワークフローが正常に動作することを確認
- [ ] Issue に `@claude <指示内容>` とコメントして、指示内容が正しく実行されることを確認
- [ ] PR に `/claude review` とコメントして、レビューが正しく実行されることを確認
- [ ] 作業完了後にコメントが自動投稿されることを確認

## Related issues

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)