### PR TITLE
feat(skills): レビュー専用 Skill (review-pr / post-review) を追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "eccube-dev-agents",
       "source": "./plugins/eccube-dev-agents",
       "description": "Git workflow automation, GitHub review management, and CI log analysis toolkit for development projects",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "nanasess"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 提供する Skills:
 1. **commit** - Conventional Commits 形式の日本語コミットメッセージ自動生成。複数リポジトリ対応
 2. **commit-push-pr** - コミット + Push + PR作成の一括実行。PRテンプレート自動適用対応
-3. **validate-review** - GitHub レビューコメントの妥当性検証
-4. **reply-review** - GitHub レビューコメントへの一括返信
-5. **github-logs-analyze** - GitHub Actions 失敗ログの解析
-6. **plan** - Issue/PR からチェックリスト形式の実装計画を生成
+3. **review-pr** - PR をレビューし、投稿せずにインラインコメントのドラフトを提示
+4. **post-review** - 確認済みドラフトを個別インラインコメントとして投稿
+5. **validate-review** - GitHub レビューコメントの妥当性検証
+6. **reply-review** - GitHub レビューコメントへの一括返信
+7. **github-logs-analyze** - GitHub Actions 失敗ログの解析
+8. **plan** - Issue/PR からチェックリスト形式の実装計画を生成
+
+### レビュー系 Skill の設計原則
+
+`review-pr` と `post-review` は「確認前に投稿しない」ことを構造で担保するために分離されている。統合や、`review-pr` への投稿処理の追加はこの担保を壊すため行わない。
+
+- `review-pr`: GitHub への POST を一切行わない（読み取り専用の `gh` のみ）
+- `post-review`: 同一会話内で `review-pr` が作成したドラフトのみを投稿対象とする
+- 指摘には `file:line` の根拠と `[VERIFIED]` / `[ASSUMED]` を付け、根拠のないものはドラフトに載せない
+
+同じ「事前確認」の関係が `validate-review` → `reply-review` にもある。
 
 ### Skill 設計パターン
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Git ワークフロー自動化、GitHub レビュー管理、CI ログ分析の
 |-------|------|--------|
 | **commit** | Conventional Commits 形式の日本語コミットメッセージ自動生成 | `/commit` |
 | **commit-push-pr** | コミット + Push + PR作成（PRテンプレート対応） | `/commit-push-pr` |
+| **review-pr** | PR をレビューし、投稿せずにドラフトを提示 | `/review-pr <PR-URL> [追加観点]` |
+| **post-review** | 確認済みドラフトを個別インラインコメントとして投稿 | `/post-review [approve] [1,3]` |
 | **validate-review** | レビューコメントの妥当性検証 | `/validate-review <URL>` |
 | **reply-review** | レビューコメントへの一括返信 | `/reply-review <URL> [@user]` |
 | **github-logs-analyze** | GitHub Actions 失敗ログの解析 | `/github-logs-analyze <job-URL>` |
@@ -18,7 +20,28 @@ Git ワークフロー自動化、GitHub レビュー管理、CI ログ分析の
 - **複数リポジトリ対応**: 親ディレクトリから実行すると変更のあるサブリポジトリを自動検出
 - **PRテンプレート対応**: `.github/pull_request_template.md` を自動検出・適用
 - **ブランチ自動作成**: デフォルトブランチにいる場合に自動でフィーチャーブランチを作成
-- **レビュー管理**: レビューコメントの妥当性検証と一括返信
+- **投稿ゲートの構造化**: レビュー（`review-pr`）と投稿（`post-review`）を別 Skill に分離し、確認前の投稿が起こらないようにする
+- **個別インラインコメント**: 指摘は該当行ごとのインラインコメントとして投稿
+
+### PR レビューの流れ
+
+```
+/review-pr https://github.com/EC-CUBE/ec-cube/pull/6958
+  → 差分読解・（必要なら）検証 → ドラフトを提示（投稿しない）
+     [1] 高 src/Eccube/Service/Foo.php:65 (RIGHT)
+     [2] 中 app/config/eccube/packages/eccube.yaml:56 (RIGHT)
+     判定案: COMMENT
+
+「1 は別 issue 済みなので除外、2 だけで approve」
+
+/post-review approve 2
+  → gh api POST .../pulls/6958/reviews --input draft.json
+  → 投稿結果を検証して報告
+```
+
+- 各指摘には `file:line` の根拠と `[VERIFIED]` / `[ASSUMED]` の検証状態を付ける
+- 根拠のない指摘はドラフトに載せない
+- `review-pr` は GitHub への POST を一切行わない
 
 ## 必要要件
 
@@ -52,6 +75,8 @@ eccube-dev-agents/
 │   └── skills/
 │       ├── commit/SKILL.md
 │       ├── commit-push-pr/SKILL.md
+│       ├── review-pr/SKILL.md
+│       ├── post-review/SKILL.md
 │       ├── validate-review/SKILL.md
 │       ├── reply-review/SKILL.md
 │       ├── github-logs-analyze/SKILL.md

--- a/plugins/eccube-dev-agents/.claude-plugin/plugin.json
+++ b/plugins/eccube-dev-agents/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "eccube-dev-agents",
   "description": "Git workflow automation, GitHub review management, and CI log analysis toolkit for development projects",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "nanasess"
   },

--- a/plugins/eccube-dev-agents/skills/post-review/SKILL.md
+++ b/plugins/eccube-dev-agents/skills/post-review/SKILL.md
@@ -1,0 +1,152 @@
+---
+description: Post a reviewed draft to GitHub as individual inline comments
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Write
+argument-hint: [approve|comment|request-changes] [投稿する指摘番号 例: 1,3-4]
+---
+
+# レビュードラフトの投稿（個別インラインコメント）
+
+`/review-pr` が作成したドラフトを、GitHub へ**個別インラインコメント**として投稿します。
+
+## 最重要ルール
+
+**同一会話内で `/review-pr` を実行して作成されたドラフトのみを投稿対象とする。**
+
+- ドラフトが存在しない場合は「投稿対象のドラフトがありません。先に `/review-pr <PR-URL>` を実行してください」と報告して終了する
+- この Skill 内で新たにレビュー内容を考え出して投稿してはならない。投稿するのは、利用者が目にしたドラフトと、利用者が指示した修正のみ
+- 利用者が採否を指示していない指摘は、ドラフトに載っていたものをそのまま投稿する（勝手に追加・削除しない）
+
+## 引数
+
+`$ARGUMENTS` から以下を解析（すべて省略可）:
+
+1. **判定**: `approve` / `comment` / `request-changes`
+   - 省略時はドラフトの `event`（`/review-pr` の判定案）を使う
+2. **投稿する指摘番号**: `1,3-4` のような指定
+   - 省略時はドラフトの全件
+   - 会話中の「1 は無視、2 だけ」「4 件独立コメントにして」「軽微なのでまとめて 1 コメントに」のような自然言語の指示も、同じ意味に解釈して反映する
+
+## 手順
+
+### 1. ドラフトの読み込み
+
+scratchpad の `review-draft-{owner}-{repo}-{number}.json` を Read する。会話中に対象 PR が複数ある場合は、直近に `/review-pr` を実行したものを対象とし、投稿前の確認でその PR 番号を明示する。
+
+### 2. 採否の反映
+
+利用者の指示に従って `comments` 配列を組み替える:
+
+- **除外**: 指定された番号の要素を削除する
+- **まとめる**: 「1 コメントにまとめて」と指示された場合は、`comments` を空にして内容を `body` に統合する
+- **分ける**: 「個別コメントにして」と指示された場合は、`body` にまとめていた内容を該当行ごとの `comments` 要素へ分解する
+- **本文の修正**: 利用者が表現や結論を変更した場合はそれを反映する
+
+`event` を決定する:
+
+| 指示 | `event` |
+|---|---|
+| approve / LGTM / 承認 | `APPROVE` |
+| change request / 要修正 | `REQUEST_CHANGES` |
+| それ以外・指定なし | `COMMENT` |
+
+**`event` は必ず設定する。**省略すると PENDING レビューになり、PR ごとに 1 件しか持てない状態のまま GitHub 上に未送信のレビューが残る。
+
+### 3. 投稿前のセルフチェック
+
+投稿コマンドを実行する前に、以下をすべて確認する:
+
+1. **HEAD SHA が最新か**
+
+   ```bash
+   gh pr view {number} --repo {owner}/{repo} --json headRefOid --jq '.headRefOid'
+   ```
+
+   ドラフトの `commit_id` と異なる場合は、レビュー中に push されている。差分を取り直して行番号がずれていないか確認し、`commit_id` を最新に更新する。ずれが大きい場合は投稿せず、再レビューが必要な旨を報告する。
+
+2. **各コメントの行が差分に含まれるか**
+
+   `gh pr diff {number} --repo {owner}/{repo}` の hunk ヘッダから、`path` / `line` / `side` の組が差分範囲内にあることを確認する。範囲外の行は 422 で投稿全体が失敗する。
+
+3. **`path` がリポジトリルートからの相対パスか**（先頭に `./` や絶対パスを含めない）
+
+4. **自分自身の PR でないか**
+
+   ```bash
+   gh pr view {number} --repo {owner}/{repo} --json author --jq '.author.login'
+   gh api user --jq '.login'
+   ```
+
+   自分の PR は `APPROVE` / `REQUEST_CHANGES` を投稿できない。一致する場合は `COMMENT` に切り替え、その旨を報告に含める。
+
+5. **未送信の PENDING レビューが残っていないか**
+
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.state=="PENDING") | {id, user: .user.login}'
+   ```
+
+   自分の PENDING レビューがあれば `gh api --method DELETE repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}` で削除してから投稿する。
+
+6. **秘密情報が本文に混入していないか**（トークン、パスワード、`.env` の値、顧客データ）
+
+### 4. 投稿
+
+組み替え後の JSON を scratchpad に書き出し、それを `--input` で渡す。本文に日本語・改行・バッククォートを含むため、`-f body=...` ではなく必ずファイル入力を使う。
+
+```bash
+gh api --method POST repos/{owner}/{repo}/pulls/{number}/reviews \
+  --input {scratchpad}/review-post-{owner}-{repo}-{number}.json \
+  --jq '{id, state, html_url}'
+```
+
+追加で 1 件だけインラインコメントを足す場合（レビューを新規に作らない）:
+
+```bash
+gh api --method POST repos/{owner}/{repo}/pulls/{number}/comments \
+  -f path='src/Foo.php' -F line=65 -f side='RIGHT' \
+  -f commit_id='{HEAD SHA}' -f body='...'
+```
+
+### 5. 投稿結果の検証
+
+投稿したレビュー ID を使い、意図した位置にコメントが付いたかを取得して確認する。
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments \
+  --jq '.[] | select(.pull_request_review_id=={review_id}) | {path, line, side, html_url}'
+```
+
+- コメント件数がドラフトと一致するか
+- `path` / `line` がずれていないか（GitHub 側で近傍行に丸められることがある）
+- レビュー本体の `state` が意図した判定になっているか
+
+### 6. 結果報告
+
+```
+## 投稿結果
+
+レビュー: {html_url}
+判定: APPROVE / COMMENT / REQUEST_CHANGES
+
+### 投稿したインラインコメント（N 件）
+- src/Eccube/Service/RefundRequestService.php:65 (RIGHT) → {コメント URL}
+- app/config/eccube/packages/eccube.yaml:56 (RIGHT) → {コメント URL}
+
+### 投稿しなかった指摘
+- [3] 別 issue で対応済みのため除外
+
+### 検証
+- コメント件数: ドラフト N 件 / 実際 N 件（一致）
+- HEAD SHA: {sha}（投稿時点で最新）
+```
+
+## エラーハンドリング
+
+| 症状 | 原因と対処 |
+|---|---|
+| `422 Unprocessable Entity` + `pull_request_review_thread.line` 系のメッセージ | 指定行が差分範囲外。`gh pr diff` で差分に含まれる行を確認し、`line` / `side` を修正する。修正できない指摘はサマリ（`body`）へ回す |
+| `422` + `user can only have one pending review` | 未送信の PENDING レビューが残っている。手順 3-5 の方法で削除してから再投稿 |
+| `422` + `Can not approve your own pull request` | 自分の PR。`event` を `COMMENT` に変更して再投稿 |
+| `403` / `404` | 権限不足またはリポジトリ名の誤り。`gh auth status` と `--repo` の値を確認 |
+| コメントが意図しない行に付いた | `commit_id` が古い可能性。該当コメントを `gh api --method DELETE repos/{owner}/{repo}/pulls/comments/{comment_id}` で削除し、最新 SHA で投稿し直す |
+
+投稿が途中で失敗した場合は、**何件が投稿済みで何件が未投稿かを必ず報告する**。レビュー作成 API は全件が 1 トランザクションで、失敗時はレビュー自体が作成されないが、`pulls/{number}/comments` を個別に呼んでいた場合は部分投稿になり得る。

--- a/plugins/eccube-dev-agents/skills/review-pr/SKILL.md
+++ b/plugins/eccube-dev-agents/skills/review-pr/SKILL.md
@@ -1,0 +1,202 @@
+---
+description: Review a GitHub PR and present an inline-comment draft without posting
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Grep, Glob, Write
+argument-hint: <PR-URL または PR番号> [追加観点]
+---
+
+# PR レビュー（投稿しないドラフト作成）
+
+GitHub PR をレビューし、**個別インラインコメントのドラフト**を作成して提示します。
+
+## 最重要ルール
+
+**この Skill は GitHub へ一切投稿しない。**
+
+- `gh pr review`、`gh api --method POST .../reviews`、`gh api --method POST .../comments`、`gh pr comment` を実行してはならない。
+- 読み取り専用の `gh` 呼び出し（`gh pr view` / `gh pr diff` / `gh api` の GET）のみ使用する。
+- 投稿は利用者がドラフトを確認したうえで `/post-review` を実行したときにのみ行われる。
+- 利用者から「そのまま投稿して」と言われた場合も、この Skill 内では投稿せず `/post-review` に引き継ぐ。
+
+## 引数
+
+`$ARGUMENTS` から以下を解析:
+
+1. **対象 PR**（いずれか）
+   - URL: `https://github.com/{owner}/{repo}/pull/{number}`
+   - 番号のみ: `6958`（カレントリポジトリの PR とみなす）
+   - 省略: `gh pr view --json number,url` でカレントブランチに紐づく PR を特定。特定できなければ利用者に確認して終了
+2. **追加観点**（自由記述、省略可）
+   - 例: 「セキュリティを重点的に」「個人情報保護法・GDPR との兼ね合いもチェック」
+   - 例: 「関連 issue の再現手順を確認して」
+   - 例: 「`~/git-repos/stripe-payment-plugin` への影響調査もお願いします」
+   - 追加観点は通常のレビュー観点に**上乗せ**する。指定されたものだけを見るのではない
+
+## 手順
+
+### 1. コンテキストの収集
+
+```bash
+# PR メタ情報（headRefOid = HEAD コミット SHA。ドラフトの commit_id に使う）
+gh pr view {number} --repo {owner}/{repo} \
+  --json number,title,body,author,baseRefName,headRefName,headRefOid,state,isDraft,mergeable,additions,deletions,changedFiles,labels,url
+
+# 差分（ローカル git diff ではなくこれを使う）
+gh pr diff {number} --repo {owner}/{repo}
+
+# 既存レビュー・既存インラインコメント（重複指摘の回避）
+gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | {user: .user.login, state, body: (.body[0:200])}'
+gh api repos/{owner}/{repo}/pulls/{number}/comments --paginate \
+  --jq '.[] | {user: .user.login, path, line, body: (.body[0:200])}'
+
+# CI 状況
+gh pr checks {number} --repo {owner}/{repo}
+```
+
+**関連 issue の確認**: PR 本文の `Closes #N` / `Refs #N` / `Fixes #N` や、利用者が提示した issue URL があれば `gh issue view N --repo {owner}/{repo} --comments` で本文とコメントを読む。issue に再現手順が書かれている場合は、それが PR の変更で解消されるかを差分から追う。
+
+**既出指摘の除外**: CodeRabbit / Gemini Code Assist / 他レビュアーが既に指摘済みの内容は、ドラフトに重複して載せない。既に別 issue 化されているものも同様。
+
+### 2. 差分の読解
+
+差分だけで判断せず、変更されたファイルの前後関係を Read で確認する。以下は毎回見る観点:
+
+- **正確性**: 分岐漏れ、null/未定義、境界値、例外経路、トランザクション境界
+- **後方互換性**: 公開 API・エンティティ・テンプレート・イベント・設定キーの削除や意味変更
+- **セキュリティ**: 入力検証、権限チェック、CSRF、XSS、SQL/コマンドインジェクション、パストラバーサル、機密情報のログ出力
+- **影響範囲**: 変更されたメソッド・定数・設定の呼び出し元を `rg` で洗い出す（1 箇所ずつではなく全件まとめて）
+- **テスト**: 変更に対応するテストの有無、テストが実際に退行を検出できるか
+- **PR の記述と実装の一致**: 本文の説明どおりの変更になっているか
+
+追加観点が指定されている場合は、その観点の調査もここで行う。
+
+### 3. 検証（任意・必要と判断した場合のみ）
+
+差分読解が主で、検証は必須ではない。ただし以下に該当する場合は実行を検討する:
+
+- 指摘の成否が実行結果に依存する（「このコードは例外になる」等の断定をしたいとき）
+- 関連 issue に再現手順があり、修正されたことを確かめたいとき
+- CI が失敗しており、原因が PR 由来かベースブランチ由来かを切り分けたいとき
+
+検証する場合の注意:
+
+- **キャッシュを先に消す**。古いキャッシュは偽陽性・偽陰性の両方を生む
+  - EC-CUBE 4系: `php bin/console cache:clear --no-warmup`、`rm -rf .phpunit.result.cache`
+  - Symfony ルートキャッシュが残っていると、存在しないはずのルートが引ける／新ルートが 404 になる
+- 実行コマンドはリポジトリの設定から決める（`composer.json` の scripts、`phpstan.neon*`、`.php-cs-fixer.dist.php`、`phpunit.xml.dist`、`package.json`）
+- ベースブランチでも同じエラーが出るかを確認してから「この PR が壊した」と書く
+
+### 4. 指摘の整理
+
+各指摘に必ず次を持たせる:
+
+| 項目 | 内容 |
+|---|---|
+| 重要度 | 高（マージ前に要対応） / 中（対応が望ましい） / 低（任意・好みの範囲） |
+| 位置 | `path` と `line`、`side`（`RIGHT`=変更後 / `LEFT`=変更前） |
+| 根拠 | `file:line` の引用、またはコマンド出力 |
+| 検証状態 | `[VERIFIED]`（コマンド出力や実コードで確認済み） / `[ASSUMED]`（推論。要確認と明示） |
+
+**根拠のない指摘はドラフトに載せない。** 「〜の可能性がある」で止まる推論は、`[ASSUMED]` を付けたうえで提示欄には出すが、投稿本文では断定形にしない。ファイル名・行番号・シンボル名は推測せず、実際に Read / `rg` で確認したものだけを書く。
+
+### 5. コメント位置の決定
+
+GitHub のレビュー API は**差分に含まれる行にしかインラインコメントを付けられない**。範囲外の行を指定すると投稿が 422 で失敗する。
+
+`gh pr diff` の hunk ヘッダ `@@ -{旧開始},{旧行数} +{新開始},{新行数} @@` から、コメント可能な行を割り出す:
+
+- **追加行 (`+`) / 文脈行 (空白始まり)** → `side: "RIGHT"`、`line` は**変更後ファイル**の行番号
+- **削除行 (`-`)** → `side: "LEFT"`、`line` は**変更前ファイル**の行番号
+- **複数行にまたがる指摘** → `start_line` + `start_side` と `line` + `side` を併用（同一 hunk 内に収める）
+- **差分に現れない行への指摘** → インラインにできない。最も近い差分行に付けて本文中でその行に言及するか、サマリ（`body`）側に回す
+
+行番号は目視で数えず、`gh pr diff` の hunk ヘッダから機械的に算出して確認する。
+
+### 6. ドラフトの保存
+
+scratchpad ディレクトリに `review-draft-{owner}-{repo}-{number}.json` として保存する（scratchpad が未設定なら `/tmp` 配下）。形式は GitHub のレビュー作成 API のリクエストボディそのもの:
+
+```json
+{
+  "commit_id": "<PR の HEAD SHA>",
+  "event": "COMMENT",
+  "body": "レビュー全体のサマリ。何を見たか、全体評価、重点確認した観点を書く。",
+  "comments": [
+    {
+      "path": "src/Eccube/Service/RefundRequestService.php",
+      "line": 65,
+      "side": "RIGHT",
+      "body": "指摘本文（Markdown 可）"
+    },
+    {
+      "path": "app/config/eccube/packages/eccube.yaml",
+      "start_line": 56,
+      "start_side": "RIGHT",
+      "line": 59,
+      "side": "RIGHT",
+      "body": "複数行にまたがる指摘"
+    }
+  ]
+}
+```
+
+`event` は判定案を入れる（`COMMENT` / `APPROVE` / `REQUEST_CHANGES`）。**`event` を省略すると PENDING レビューになり、PR ごとに 1 件しか持てない状態になるため、必ず設定する。**
+
+指摘本文の書き方:
+
+- 日本語。「何が」「なぜ問題か」「どう直すか」を順に書く
+- 修正案があるコードは fenced code block または GitHub の `suggestion` ブロックで示す
+- 断定できないことは「〜という認識ですが、いかがでしょうか」と質問形にする
+- 相手の対応を確認したうえでの再レビューなら、冒頭に `@{author}` を付ける
+
+### 7. 提示（投稿しない）
+
+以下の形式で報告する:
+
+```
+## レビュー結果（未投稿）
+
+対象: {owner}/{repo}#{number}「{title}」
+      {author} / {base} ← {head} / {changedFiles} files +{additions} -{deletions}
+CI: {pass/fail の要約}
+既存レビュー: {重複を除外した件数など}
+
+### 判定案: COMMENT（理由: 高 1 件・中 2 件のため要対応）
+
+### インラインコメント案
+
+**[1] 高 `src/Eccube/Service/RefundRequestService.php:65` (RIGHT)**
+拡張子がクライアント申告値にフォールバックしている
+- 根拠: [VERIFIED] `RefundRequestService.php:65` で `guessExtension() ?: $file->getClientOriginalExtension()`
+- 本文案: （投稿する本文）
+
+**[2] 中 `app/config/eccube/packages/eccube.yaml:56` (RIGHT)**
+...
+
+### サマリ（body）案
+（投稿する body 本文）
+
+### 除外した指摘
+- CodeRabbit が #6529 で指摘済みのため除外: ...
+- 根拠が取れなかったため除外: ...
+
+### ドラフト
+{ドラフト JSON のパス}
+
+### 投稿するには
+- そのまま全件: `/post-review`
+- 判定を変える: `/post-review approve`
+- 一部だけ: `/post-review approve 1,3`
+- 「1 は無視して 2 だけ、approve で」のような自然言語の指示でも可
+```
+
+## 補足
+
+- PR が draft / closed / merged の場合は、その旨を先に報告してから続行するか確認する
+- 差分が巨大な場合はファイル単位で優先順位を付け、見ていない範囲を報告に明記する（黙って打ち切らない）
+- ローカルの他リポジトリへの影響調査を指示された場合は、そのパスを Read / `rg` で確認し、影響の有無を根拠付きで報告する
+
+## エラーハンドリング
+
+- PR が特定できない: URL か番号の指定を促す
+- `gh` 未認証: `gh auth login` を案内
+- 対象リポジトリが手元に無く差分だけで判断が付かない: その旨を明記し、判断できた範囲のみをドラフトにする


### PR DESCRIPTION
## Summary

PR レビューを **ドラフト作成** と **投稿** の 2 Skill に分離し、確認前の投稿が起こらないことを構造で担保する。

公式 `/review` は確認前に投稿してしまうため、投稿前にドラフトを確認したい、という運用上の要求に対応した。投稿形式は個別インラインコメント。

`/insights` 2026-07 レポートの次のアクション候補「PR レビュー (最頻 25 セッション) の仕組み化 — 既存の eccube-dev-agents には reply-review / validate-review はあるが、**レビュー実行そのもののスキルは無い**」への対応。

## Changes

### `review-pr` (新規)

`/review-pr <PR-URL または番号> [追加観点]`

- **GitHub へ一切投稿しない** — `gh pr review` / POST 系の使用を禁止し、読み取り専用の `gh` のみ許可。「そのまま投稿して」と言われても `post-review` に引き継ぐ
- 引数は PR URL / 番号 / 省略 (カレントブランチ)。追加観点 (セキュリティ重点、GDPR、他リポジトリへの影響調査、関連 issue の再現) は通常観点に上乗せ
- 既存レビュー・インラインコメントを取得し、CodeRabbit 等の既出指摘を除外
- 検証は任意。実行時の注意として EC-CUBE 4系のキャッシュクリア (`cache:clear --no-warmup`、`.phpunit.result.cache` 削除) と、ベースブランチでも再現するか確認してから PR 由来と書くことを明記
- 各指摘に `file:line` の根拠と `[VERIFIED]` / `[ASSUMED]` を必須化。根拠のない指摘はドラフトに載せない
- インライン位置は hunk ヘッダ `@@ -a,b +c,d @@` から機械的に算出 (追加行→`RIGHT`、削除行→`LEFT`、複数行は `start_line`)。差分範囲外は 422 になる旨を明記
- ドラフトは scratchpad の `review-draft-{owner}-{repo}-{number}.json` に保存

### `post-review` (新規)

`/post-review [approve|comment|request-changes] [1,3-4]`

- `reply-review` と同じガード — 同一会話内で `review-pr` が作成したドラフトのみを投稿対象とする
- 「1 は無視、2 だけ」「4件独立コメントに」「1つにまとめて」といった自然言語の指示も解釈ルールとして記載
- 投稿前セルフチェック: HEAD SHA の鮮度 / 行が差分範囲内か / 自己 PR (APPROVE 不可 → COMMENT にフォールバック) / PENDING レビューの残存 / 秘密情報の混入
- 投稿は `gh api --method POST repos/{owner}/{repo}/pulls/{n}/reviews --input <json>`
- 投稿後に `pull_request_review_id` で取り直し、path/line のずれを検証

### その他

- `README.md`: Skill 表にレビューの流れを追記
- `CLAUDE.md`: 「レビュー系 Skill の設計原則」として、統合や `review-pr` への投稿処理追加が投稿ゲートを壊すことを明記
- `plugin.json` / `marketplace.json`: 2.0.0 → 2.1.0

## Test plan

- [x] 全 8 Skill のフロントマターが既存と同一キー構成 (`description` / `allowed-tools` / `argument-hint`) でパース可能
- [x] `headRefOid` が `gh 2.96.0` の有効フィールドであることを `gh pr view --json` の候補一覧で確認
- [x] `review-pr` 手順 1 のコマンド群を実 PR (EC-CUBE/ec-cube#6977) で実行し、メタ情報取得と hunk ヘッダ抽出が動作することを確認
- [x] 投稿ペイロード形式が実投稿実績 (EC-CUBE/ec-cube#6838) と一致
- [x] 実 PR での `/review-pr` → `/post-review` のエンドツーエンド動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * PRレビュー用のドラフト作成機能と、確認済みレビューの投稿機能を追加しました。
  * レビュー内容にファイル位置や検証状態を付けて管理できるようになりました。
  * 投稿前の差分・位置・重複・秘密情報などの確認手順を整備しました。
* **ドキュメント**
  * 新機能の利用手順、レビューの流れ、エラー時の対応をREADMEとガイドに追加しました。
* **メンテナンス**
  * プラグインのバージョンを2.1.0へ更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->